### PR TITLE
Invalid cast if /ANNOTS is not a PdfArray

### DIFF
--- a/src/core/iTextSharp/text/pdf/AcroFields.cs
+++ b/src/core/iTextSharp/text/pdf/AcroFields.cs
@@ -134,8 +134,8 @@ namespace iTextSharp.text.pdf {
                 return;
             for (int k = 1; k <= reader.NumberOfPages; ++k) {
                 PdfDictionary page = reader.GetPageNRelease(k);
-                PdfArray annots = (PdfArray)PdfReader.GetPdfObjectRelease(page.Get(PdfName.ANNOTS), page);
-                if (annots == null)
+                PdfObject pdfObject = PdfReader.GetPdfObjectRelease(page.Get(PdfName.ANNOTS), page);
+                if (!(pdfObject is PdfArray annots))
                     continue;
                 for (int j = 0; j < annots.Size; ++j) {
                     PdfDictionary annot = annots.GetAsDict(j);


### PR DESCRIPTION
Although ISO 32000 says that an /ANNOTS must be array, we have seen some rare cases where it is an indirect reference to the /CONTENTS of another page and this caused it to crash when trying to cascade.

Given that the firm is still valid if we ignore that /ANNOTS is not a PdfArray we are going to make a check to avoid the crash.