### PR TITLE
Use UTF-16BE to codify PDF producer name

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfStamperImp.cs
+++ b/src/core/iTextSharp/text/pdf/PdfStamperImp.cs
@@ -200,7 +200,7 @@ namespace iTextSharp.text.pdf {
             if (iInfo != null)
                 skipInfo = iInfo.Number;
             if (oldInfo != null && oldInfo.Get(PdfName.PRODUCER) != null)
-                producer = oldInfo.GetAsString(PdfName.PRODUCER).ToString();
+                producer = oldInfo.GetAsString(PdfName.PRODUCER).ToUnicodeString();
             if (producer == null) {
                 producer = Document.Version;
             }
@@ -323,7 +323,7 @@ namespace iTextSharp.text.pdf {
                 }
             }
             newInfo.Put(PdfName.MODDATE, date);
-            newInfo.Put(PdfName.PRODUCER, new PdfString(producer));
+            newInfo.Put(PdfName.PRODUCER, new PdfString(producer, PdfObject.TEXT_UNICODE));
             if (append) {
                 if (iInfo == null)
                     info = AddToBody(newInfo, false).IndirectReference;


### PR DESCRIPTION
<img width="651" height="62" alt="image" src="https://github.com/user-attachments/assets/61244d6c-42ba-4b71-8e5f-c6e7ba64882f" />

EDITED:

When using the stamper to create a signature in two different pdfs I saw something curious:
Right now, if /producer already exists in the original pdf this is respected.

1. The PDF signed with the producer “Nevrona Designs” ends up with the producer ok.
2. The PDF signed with the producer "macOS Versión 12.7.6 (Compilación 21H1320) Quartz PDFContext, AppendMode 1.1" ends with a corrupted producer.

The requested change is based on https://github.com/LibrePDF/OpenPDF/commit/6ceda3dec2565eb9659b11b7de7ed566aa8fa587